### PR TITLE
use direct EC key APIs for parsing x509 certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 PROJECT_NAME := manetu-login-policy
 GO_FILES := $(shell find . -name '*.go' | grep -v /vendor/ | grep -v _test.go)
 
-.PHONY: all clean lint test goimports staticcheck tests sec-scan
+.PHONY: all clean lint test goimports staticcheck tests sec-scan bin
 
-all: lint test race staticcheck goimports sec-scan
+all: lint test race staticcheck goimports sec-scan bin
 
 lint: ## Run unittests
 	@printf "\033[36m%-30s\033[0m %s\n" "### make $@"
@@ -34,7 +34,11 @@ goimports: ## Run goimports
 
 clean: ## Remove previous build
 	@printf "\033[36m%-30s\033[0m %s\n" "### make $@"
-	@rm go.sum
+	@-rm manetu-security-token
+
+bin: ## Build the exe
+	@printf "\033[36m%-30s\033[0m %s\n" "### make $@"
+	@go build -o manetu-security-token
 
 sec-scan: ## Run gosec; see https://github.com/securego/gosec
 	@gosec ./...

--- a/config/backend.go
+++ b/config/backend.go
@@ -5,6 +5,6 @@ Copyright © 2021-2022 Manetu Inc. All Rights Reserved.
 package config
 
 type BackendConfiguration struct {
-	TokenURL   string
-	ProviderID string
+	TokenURL string
+	RealmID  string
 }

--- a/main.go
+++ b/main.go
@@ -34,16 +34,16 @@ func main() {
 				Usage: "Generate a new security token",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "provider",
-						Usage: "Set the provider id",
+						Name:  "realm",
+						Usage: "Set the realm id",
 					},
 				},
 				Action: func(c *cli.Context) error {
-					provider := c.String("provider")
-					if provider == "" {
-						provider = ctx.Backend.ProviderID
+					realm := c.String("realm")
+					if realm == "" {
+						realm = ctx.Backend.RealmID
 					}
-					cert, err := ctx.Generate(provider)
+					cert, err := ctx.Generate(realm)
 					st.Check(err)
 
 					fmt.Printf("Serial: %s\n", st.HexEncode(cert.SerialNumber.Bytes()))
@@ -112,8 +112,8 @@ func main() {
 						},
 					},
 					{
-						Name:  "x509",
-						Usage: "X509 based login",
+						Name:  "pem",
+						Usage: "non-HSM protected PEM encoded certificate and key-pair",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "key",

--- a/security-tokens.yml
+++ b/security-tokens.yml
@@ -5,4 +5,4 @@ pkcs11:
 
 backend:
   tokenurl: "https://portal.eu.manetu.io/oauth/token"
-  providerid: "piedpiper"
+  realmId: "piedpiper"


### PR DESCRIPTION
Dependence on PKCS8 format causes unncessary usability headaches.

Also changed "ProviderID" to "RealmID" and added some text to aid generating the correct key/cert for use with Service Accounts.